### PR TITLE
Install aws cli from pip instead of apt.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM ubuntu
 
 MAINTAINER Sergey Zhukov, sergey@jetbrains.com
 
-RUN apt-get update && apt-get install -y jq awscli
+RUN apt-get update && apt-get install -y jq python-pip && pip install --upgrade pip && pip install awscli


### PR DESCRIPTION
It's needed to fix the following issue: https://github.com/aws/aws-cli/issues/1926.